### PR TITLE
Added the option to configure Thumbnail size (XXLarge, XLarge, Large and Small).

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -14,7 +14,7 @@ import pytz
 from datetime import datetime, timedelta
 
 # Consts used
-VERSION = ' V0.0.0.11'
+VERSION = ' V0.0.0.12'
 NAME = 'epg-dk'
 DESCRIPTION = 'Download a program Guide from YouSee Denmark'
 ART = 'art-default.jpg'
@@ -23,7 +23,7 @@ PREFIX = '/applications/epg-dk'
 APPGUID = '76a8cf36-7c2b-11e4-8b4d-00079cdf80b2'
 BASEURL = 'http://api.yousee.tv/rest/tvguide/'
 HEADER = {'X-API-KEY' : 'HCN2BMuByjWnrBF4rUncEfFBMXDumku7nfT3CMnn'}
-PROGRAMSTOGRAB = '10'
+PROGRAMSTOGRAB = '20'
 bFirstRun = False
 DEBUGMODE = False
 FIELDS = 'id,channel,begin,end,title,description,imageprefix,images_fourbythree,is_series,series_info,category_string,subcategory_string,directors,cast/startIndex'
@@ -109,6 +109,15 @@ def createXMLFile(menuCall = False):
 @route(PREFIX + '/createXMLFile')
 def doCreateXMLFile(menuCall = False):
 	xmlFile = Prefs['Store_Path']
+
+	# Thumbnail Size
+	thumbSize = 'xxlarge'
+	rxThumbSize = re.compile('^([a-zA-Z]+)')
+	mThumbSize = rxThumbSize.match(str(Prefs['Thumb_Size']))
+	if mThumbSize:
+		thumbSize = mThumbSize.group(0).lower()
+	Log.Debug('Thumbnail size parsed: %s from %s' %(thumbSize, Prefs['Thumb_Size']))
+	
 	root = ET.Element("tv")
 	root.set('generator-info-name', NAME)
 	root.set('date', datetime.now().strftime('%Y%m%d%H%M%S'))
@@ -131,7 +140,7 @@ def doCreateXMLFile(menuCall = False):
 		for Program in Programs:		
 			startTime = (datetime.utcfromtimestamp(Program['begin']) + timedelta(hours=DSTHOURS)).strftime('%Y%m%d%H%M%S') + ' ' + OFFSET
 			stopTime = (datetime.utcfromtimestamp(Program['end']) + timedelta(hours=DSTHOURS)).strftime('%Y%m%d%H%M%S') + ' ' + OFFSET
-			poster = Program['imageprefix'] + Program['images_fourbythree']['xxlarge']
+			poster = Program['imageprefix'] + Program['images_fourbythree'][thumbSize]
 			program = ET.SubElement(root, 'programme', start=startTime, stop=stopTime, channel=str(Program['channel']), id=str(Program['id']))
 			title = ValidateXMLStr(Program['title'])
 			description = ValidateXMLStr(Program['description'])

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -6,6 +6,13 @@
 		"default": "/somedir/somefile.xml   or C:\\Somedir\\Somefile.xml"
 	},
 	{
+		"id": "Thumb_Size",
+		"type": "enum",
+		"label": "Thumbnail size (1440x1080, 960x720, 713x535 or 156x117)",
+		"values": ["XXLarge (1440x1080)", "XLarge (960x720)", "Large (713x535)", "Small (156x117)"],
+		"default": "XXLarge (1440x1080)"
+	},
+	{
 		"id":"DaysToFetch",
 		"label":"Amount of days to fetch. This number most be in the range of 1 to 7",
 		"type":"text",

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+v0.0.0.12:
+	- Settings:
+		- Added the option to configure Thumbnail size (XXLarge, XLarge, Large and Small).
+
 v0.0.0.11:
 	- General:
 		- Updated "sub-title" parser. Would in some strange cases extract partial sub-title ex. "(m)" or "(k)".


### PR DESCRIPTION
Android user could have trouble showing large thumbnails (#21). Added the option to configure the size.

<img width="513" alt="screenshot_1" src="https://user-images.githubusercontent.com/992714/29748420-e06b4f5c-8b16-11e7-9818-be7a1ddf9821.png">
 